### PR TITLE
Fixed quote custom fields

### DIFF
--- a/views/format-quote.php
+++ b/views/format-quote.php
@@ -1,10 +1,10 @@
 <div id="cfpf-format-quote-fields" style="display: none;">
 	<div class="cp-elm-block">
-		<label for="cfpf-format-quote-source-name"><?php _e('Source Name', 'cf-post-format'); ?></label>
-		<input type="text" name="_format_quote_source_name" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_name', true)); ?>" id="cfpf-format-quote-source-name" tabindex="1" />
+		<label for="cfpf-format-quote-src-name"><?php _e('src Name', 'cf-post-format'); ?></label>
+		<input type="text" name="_format_quote_src_name" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_src_name', true)); ?>" id="cfpf-format-quote-src-name" tabindex="1" />
 	</div>
 	<div class="cp-elm-block">
-		<label for="cfpf-format-quote-source-url"><?php _e('Source URL', 'cf-post-format'); ?></label>
-		<input type="text" name="_format_quote_source_url" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_url', true)); ?>" id="cfpf-format-quote-source-url" tabindex="1" />
+		<label for="cfpf-format-quote-src-url"><?php _e('src URL', 'cf-post-format'); ?></label>
+		<input type="text" name="_format_quote_src_url" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_src_url', true)); ?>" id="cfpf-format-quote-src-url" tabindex="1" />
 	</div>
 </div>


### PR DESCRIPTION
The custom fields in the format-quote.php didn't match up with the
documentation on
http://alexking.org/blog/2011/10/25/wordpress-post-formats-admin-ui
