### PR TITLE
Updated cfpf_base_url() to work regardless of directory location

### DIFF
--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -33,7 +33,7 @@ Author URI: http://crowdfavorite.com
 define('CFPF_VERSION', '0.2');
 
 function cfpf_base_url() {
-	return trailingslashit(apply_filters('cfpf_base_url', plugins_url('', __FILE__)));
+	return trailingslashit(apply_filters('cfpf_base_url', get_bloginfo('url').str_replace($_SERVER["DOCUMENT_ROOT"], '', dirname(__FILE__))));
 }
 
 // we aren't really adding meta boxes here,

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,4 +1,3 @@
-
 #formatdiv, /* hide default radio button UI */
 #titlewrap {
 	display: none;
@@ -80,6 +79,13 @@
 .cp-elm-block .cp-elm-image-gallery dt {
 	margin: 0 5px 5px 0;
 	padding: 0;
+}
+
+.cp-elm-block .cp-elm-container .gallery dt img {
+	width: 90%;
+	height: auto;
+	margin: 5%;
+	border: none;
 }
 
 /* Video Field */

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -3,7 +3,7 @@
 	<div class="cp-elm-container">
 
 <?php
-	echo do_shortcode('[gallery columns="9999"]');
+	echo do_shortcode('[gallery columns="6"]');
 ?>
 <p class="none"><a href="#" class="button"><?php _e('Upload Images', 'cf-post-format'); ?></a></p>
 	</div>


### PR DESCRIPTION
Updated cfpf_base_url() to work regardless of directory location, allowing plugin to be used both as a WordPress plugin, but also as an include in a theme's functions.php file. Doing so allows theme developers to include the functionality without asking users to install a plugin.

Also fixes problem #8.
