### PR TITLE
Fix Display On Pages

### DIFF
--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -78,6 +78,7 @@ function cfpf_add_meta_boxes($post_type) {
 		);
 		
 		add_action('edit_form_advanced', 'cfpf_post_admin_setup');
+		add_action('edit_page_form', 'cfpf_post_admin_setup');
 	}
 }
 add_action('add_meta_boxes', 'cfpf_add_meta_boxes');

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -77,8 +77,7 @@ function cfpf_add_meta_boxes($post_type) {
 			)
 		);
 		
-		add_action('edit_form_advanced', 'cfpf_post_admin_setup');
-		add_action('edit_page_form', 'cfpf_post_admin_setup');
+		add_action('edit_form_after_title', 'cfpf_post_admin_setup');
 	}
 }
 add_action('add_meta_boxes', 'cfpf_add_meta_boxes');


### PR DESCRIPTION
added an additional add_action on line 81 as the edit_form_advanced doesn't seem to work on pages.  The admin now displays and functions on 'pages' when post formats are enabled for pages as well.
