### PR TITLE
Added title and date fields to quote format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# WordPress Post Formats Admin UI
+
+* https://github.com/crowdfavorite/wp-post-formats
+* https://github.com/crowdfavorite/wp-post-formats-fallback
+* http://alexking.org/blog/2011/10/25/wordpress-post-formats-admin-ui
+* http://core.trac.wordpress.org/ticket/19570

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -158,6 +158,8 @@ function cfpf_format_quote_save_post($post_id, $post) {
 	if (!defined('XMLRPC_REQUEST')) {
 		$keys = array(
 			'_format_quote_source_name',
+			'_format_quote_source_title',
+			'_format_quote_source_date',
 			'_format_quote_source_url',
 		);
 		foreach ($keys as $key) {

--- a/views/format-quote.php
+++ b/views/format-quote.php
@@ -4,6 +4,14 @@
 		<input type="text" name="_format_quote_source_name" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_name', true)); ?>" id="cfpf-format-quote-source-name" tabindex="1" />
 	</div>
 	<div class="cf-elm-block">
+		<label for="cfpf-format-quote-source-name"><?php _e('Source Title', 'cf-post-format'); ?></label>
+		<input type="text" name="_format_quote_source_title" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_title', true)); ?>" id="cfpf-format-quote-source-name" tabindex="1" />
+	</div>
+	<div class="cf-elm-block">
+		<label for="cfpf-format-quote-source-name"><?php _e('Source Date', 'cf-post-format'); ?></label>
+		<input type="text" name="_format_quote_source_date" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_date', true)); ?>" id="cfpf-format-quote-source-name" tabindex="1" />
+	</div>
+	<div class="cf-elm-block">
 		<label for="cfpf-format-quote-source-url"><?php _e('Source URL', 'cf-post-format'); ?></label>
 		<input type="text" name="_format_quote_source_url" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_url', true)); ?>" id="cfpf-format-quote-source-url" tabindex="1" />
 	</div>


### PR DESCRIPTION
Without a "title" field there is no way to mark up quote credits with
the cite tag in a way that conforms to the HTML5 spec. Cite is only
meant to be applied to the title of a work, not the name of a person. I
included date since a year is often given. Ultimately this will allow
theme authors to follow the "Name, Title, Date" convention of quote
credits while conforming to the HTML5 spec.
