### PR TITLE
Added title and date fields to quote format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Alex King's post about this project:
 Open ticket on the WordPress trac proposing to commit this code to core:
 
 * http://core.trac.wordpress.org/ticket/19570
+
+Personal to do list and general notes:
+
+* AJAXify autotitling? Currently have to save a draft before a slug is created = post has a numeric slug.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# WordPress Post Formats Admin UI
+
+* https://github.com/crowdfavorite/wp-post-formats
+* https://github.com/crowdfavorite/wp-post-formats-fallback
+* http://alexking.org/blog/2011/10/25/wordpress-post-formats-admin-ui
+* http://core.trac.wordpress.org/ticket/19570

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
 # CF Post Formats
 
-GitHub repos:
+This is my fork of [CF Post Formats](https://github.com/crowdfavorite/wp-post-formats), a WordPress plugin that improves on the default post format UI.
 
-* https://github.com/crowdfavorite/wp-post-formats
-* https://github.com/crowdfavorite/wp-post-formats-fallback
+* [Alex King's post about this project](http://alexking.org/blog/2011/10/25/wordpress-post-formats-admin-ui).
+* [Original ticket on the WordPress trac](http://core.trac.wordpress.org/ticket/19570).
+* [Post formats UI exist WordPress 3.6 core](http://make.wordpress.org/core/2013/05/29/post-formats-ui-is-exiting-core-will-live-as-a-plugin/).
+* Merged with version 1.3.1 of the original plugin.
+* Compatible with WordPress 3.8.1.
 
-Alex King's post about this project:
+Modifications to the original plugin in this fork:
 
-* http://alexking.org/blog/2011/10/25/wordpress-post-formats-admin-ui
-
-Open ticket on the WordPress trac proposing to commit this code to core:
-
-* http://core.trac.wordpress.org/ticket/19570
-
-Personal to do list and general notes:
-
-* AJAXify autotitling? Currently have to save a draft before a slug is created = post has a numeric slug.
+* Title and date fields added to the quotation post format UI to [allow compliance with the HTML5 specification](http://synapticism.com/working-with-wordpress-post-formats-and-quotations/).
+* Autotitle feature now based on 10 words rather than 50 characters.
+* Autotitle feature currently requires saving a draft before the slug is created.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# CF Post Formats
+
+GitHub repos:
+
+* https://github.com/crowdfavorite/wp-post-formats
+* https://github.com/crowdfavorite/wp-post-formats-fallback
+
+Alex King's post about this project:
+
+* http://alexking.org/blog/2011/10/25/wordpress-post-formats-admin-ui
+
+Open ticket on the WordPress trac proposing to commit this code to core:
+
+* http://core.trac.wordpress.org/ticket/19570

--- a/README.md
+++ b/README.md
@@ -1,6 +1,0 @@
-# WordPress Post Formats Admin UI
-
-* https://github.com/crowdfavorite/wp-post-formats
-* https://github.com/crowdfavorite/wp-post-formats-fallback
-* http://alexking.org/blog/2011/10/25/wordpress-post-formats-admin-ui
-* http://core.trac.wordpress.org/ticket/19570

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -141,11 +141,11 @@ function cfpf_format_auto_title_post($post_id, $post) {
 	$words = 10;
 	preg_match("/(\S+\s*){0,$words}/", trim(strip_tags($post->post_content)), $result);
 
-  	// Trim punctuaction, symbols, and whitespace from the beginning and end of the title
-  	$title = preg_replace("/^[\p{P}|\p{S}|\s]+|[\p{P}|\p{S}|\s]+$/", "", $result[0]);
-  	// Alternately: $title = trim($result[0], ' ?!:;.,_-~<>(){}[]\'"`/\\+=');
-	
-  	// Add an ellipsis if the word count is maxed out
+  // Trim punctuaction, symbols, and whitespace from the beginning and end of the title
+  $title = preg_replace("/^[\p{P}|\p{S}|\s]+|[\p{P}|\p{S}|\s]+$/", "", $result[0]);
+  // Alternately: $title = trim($result[0], ' ?!:;.,_-~<>(){}[]\'"`/\\+=');
+
+  // Add an ellipsis if the word count is maxed out
 	if (str_word_count($title) >= $words) {
 		$title .= '...';
 	}

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -133,10 +133,15 @@ function cfpf_format_auto_title_post($post_id, $post) {
 	remove_action('save_post', 'cfpf_format_quote_save_post', 10, 2);
 
 	$content = trim(strip_tags($post->post_content));
-	$title = substr($content, 0, 50);
+	//$title = substr($content, 0, 50);
+	// Break down titles by words instead of characters
+	$words = 10;
+	preg_match("/(\S+\s*){0,$words}/", $content, $result);
+  	$title = trim($result[0]);
 	if (strlen($content) > 50) {
 		$title .= '...';
 	}
+
 	$title = apply_filters('cfpf_format_auto_title', $title, $post);
 	wp_update_post(array(
 		'ID' => $post_id,

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -158,6 +158,8 @@ function cfpf_format_quote_save_post($post_id, $post) {
 	if (!defined('XMLRPC_REQUEST')) {
 		$keys = array(
 			'_format_quote_source_name',
+			'_format_quote_source_title',
+			'_format_quote_source_date',
 			'_format_quote_source_url',
 		);
 		foreach ($keys as $key) {

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -132,13 +132,16 @@ function cfpf_format_auto_title_post($post_id, $post) {
 	remove_action('save_post', 'cfpf_format_status_save_post', 10, 2);
 	remove_action('save_post', 'cfpf_format_quote_save_post', 10, 2);
 
-	$content = trim(strip_tags($post->post_content));
-	//$title = substr($content, 0, 50);
-	// Break down titles by words instead of characters
+	// Break down titles by words instead of characters and strip punctuation
 	$words = 10;
-	preg_match("/(\S+\s*){0,$words}/", $content, $result);
-  	$title = trim($result[0]);
-	if (strlen($content) > 50) {
+	preg_match("/(\S+\s*){0,$words}/", trim(strip_tags($post->post_content)), $result);
+
+  	// Trim punctuaction, symbols, and whitespace from the beginning and end of the title
+  	$title = preg_replace("/^[\p{P}|\p{S}|\s]+|[\p{P}|\p{S}|\s]+$/", "", $result[0]);
+  	// Alternately: $title = trim($result[0], ' ?!:;.,_-~<>(){}[]\'"`/\\+=');
+	
+  	// Add an ellipsis if the word count is maxed out
+	if (str_word_count($title) >= $words) {
 		$title .= '...';
 	}
 

--- a/views/format-quote.php
+++ b/views/format-quote.php
@@ -4,6 +4,14 @@
 		<input type="text" name="_format_quote_source_name" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_name', true)); ?>" id="cfpf-format-quote-source-name" tabindex="1" />
 	</div>
 	<div class="cf-elm-block">
+		<label for="cfpf-format-quote-source-name"><?php _e('Source Title', 'cf-post-format'); ?></label>
+		<input type="text" name="_format_quote_source_title" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_title', true)); ?>" id="cfpf-format-quote-source-name" tabindex="1" />
+	</div>
+	<div class="cf-elm-block">
+		<label for="cfpf-format-quote-source-name"><?php _e('Source Date', 'cf-post-format'); ?></label>
+		<input type="text" name="_format_quote_source_date" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_date', true)); ?>" id="cfpf-format-quote-source-name" tabindex="1" />
+	</div>
+	<div class="cf-elm-block">
 		<label for="cfpf-format-quote-source-url"><?php _e('Source URL', 'cf-post-format'); ?></label>
 		<input type="text" name="_format_quote_source_url" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_quote_source_url', true)); ?>" id="cfpf-format-quote-source-url" tabindex="1" />
 	</div>


### PR DESCRIPTION
Without a "title" field there is no way to mark up quote credits with
the cite tag in a way that conforms to the HTML5 spec. Cite is only
meant to be applied to the title of a work, not the name of a person. I
included date since a year is often given. Ultimately this will allow
theme authors to follow the "Name, Title, Date" convention of quote
credits while conforming to the HTML5 spec.
