### PR TITLE
Only run cfpf_format_auto_title_post() if the post title does not alread...

### DIFF
--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -130,7 +130,7 @@ function cfpf_format_link_save_post($post_id) {
 
 function cfpf_format_auto_title_post($post_id, $post) {
 
-	if ( $post->post_title ) {
+	if ( empty($post->post_title) ) {
 
 		remove_action('save_post', 'cfpf_format_status_save_post', 10, 2);
 		remove_action('save_post', 'cfpf_format_quote_save_post', 10, 2);

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -5,7 +5,7 @@ Plugin URI: http://crowdfavorite.com
 Description: Custom post format admin UI
 Version: 1.1
 Author: crowdfavorite
-Author URI: http://crowdfavorite.com 
+Author URI: http://crowdfavorite.com
 */
 
 /**
@@ -22,7 +22,7 @@ Author URI: http://crowdfavorite.com
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -69,14 +69,14 @@ function cfpf_add_meta_boxes($post_type) {
 		wp_enqueue_style('cf-post-formats', cfpf_base_url().'css/admin.css', array(), CFPF_VERSION, 'screen');
 
 		wp_localize_script(
-			'cf-post-formats', 
-			'cfpf_post_format', 
+			'cf-post-formats',
+			'cfpf_post_format',
 			array(
 				'loading' => __('Loading...', 'cf-post-formats'),
 				'wpspin_light' => admin_url('images/wpspin_light.gif')
 			)
 		);
-		
+
 		add_action('edit_form_after_title', 'cfpf_post_admin_setup');
 	}
 }
@@ -94,7 +94,7 @@ function cfpf_post_admin_setup() {
 		global $post;
 		$current_post_format = get_post_format($post->ID);
 
-		// support the possibility of people having hacked in custom 
+		// support the possibility of people having hacked in custom
 		// post-formats or that this theme doesn't natively support
 		// the post-format in the current post - a tab will be added
 		// for this format but the default WP post UI will be shown ~sp
@@ -129,22 +129,28 @@ function cfpf_format_link_save_post($post_id) {
 // action added in cfpf_admin_init()
 
 function cfpf_format_auto_title_post($post_id, $post) {
-	remove_action('save_post', 'cfpf_format_status_save_post', 10, 2);
-	remove_action('save_post', 'cfpf_format_quote_save_post', 10, 2);
 
-	$content = trim(strip_tags($post->post_content));
-	$title = substr($content, 0, 50);
-	if (strlen($content) > 50) {
-		$title .= '...';
+	if ( $post->post_title ) {
+
+		remove_action('save_post', 'cfpf_format_status_save_post', 10, 2);
+		remove_action('save_post', 'cfpf_format_quote_save_post', 10, 2);
+
+		$content = trim(strip_tags($post->post_content));
+		$title = substr($content, 0, 50);
+		if (strlen($content) > 50) {
+			$title .= '...';
+		}
+		$title = apply_filters('cfpf_format_auto_title', $title, $post);
+		wp_update_post(array(
+			'ID' => $post_id,
+			'post_title' => $title
+		));
+
+		add_action('save_post', 'cfpf_format_status_save_post', 10, 2);
+		add_action('save_post', 'cfpf_format_quote_save_post', 10, 2);
+
 	}
-	$title = apply_filters('cfpf_format_auto_title', $title, $post);
-	wp_update_post(array(
-		'ID' => $post_id,
-		'post_title' => $title
-	));
 
-	add_action('save_post', 'cfpf_format_status_save_post', 10, 2);
-	add_action('save_post', 'cfpf_format_quote_save_post', 10, 2);
 }
 
 function cfpf_format_status_save_post($post_id, $post) {


### PR DESCRIPTION
...y exist. This keeps the_title() from being overwritten.

I recently used this plugin for an existing blog and converted some old posts to quote post format. It was then decided to keep the_title() in place as it was before. All the posts that were converted with this plugin required editing to set the_title() back to what it was before.

With this change existing posts will not have the_title() overwritten. New posts with have the_title() set.
