### PR TITLE
Fixes "creating default object from empty value" warning.

### DIFF
--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -196,7 +196,7 @@ function cfpf_gallery_preview() {
 		exit;
 	}
 	global $post;
-	$post->ID = $post_id;
+	$post = get_post($post_id);
 	ob_start();
 	include('views/format-gallery.php');
 	$html = ob_get_clean();


### PR DESCRIPTION
Resolves the following PHP warning message:

> **Warning:** Creating default object from empty value

This warning was caused because `$post` had not been set, i.e., it was null.

If we don't like `get_post($post_id)`, then the following workaround would also get rid of the warning:

```
$post = is_object($post)?$post:new stdClass();
$post->ID = $post_id;
```

You would insert that near [L199](https://github.com/crowdfavorite/wp-post-formats/blob/develop/cf-post-formats.php#L199).
