### PR TITLE
Gallery radio buttons

### DIFF
--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -56,6 +56,9 @@ function cfpf_admin_init() {
 		if (in_array('audio', $post_formats[0])) {
 			add_action('save_post', 'cfpf_format_audio_save_post');
 		}
+		if (in_array('gallery', $post_formats[0])) {
+			add_action('save_post', 'cfpf_format_gallery_save_post');
+		}
 	}
 }
 add_action('admin_init', 'cfpf_admin_init');
@@ -187,6 +190,19 @@ function cfpf_format_video_save_post($post_id) {
 function cfpf_format_audio_save_post($post_id) {
 	if (!defined('XMLRPC_REQUEST') && isset($_POST['_format_audio_embed'])) {
 		update_post_meta($post_id, '_format_audio_embed', $_POST['_format_audio_embed']);
+	}
+}
+// action added in cfpf_admin_init()
+
+function cfpf_format_gallery_save_post($post_id) {
+	if (!defined('XMLRPC_REQUEST') && isset($_POST['_format_gallery_preview_shortcode'])) {
+		update_post_meta($post_id, '_format_gallery_preview_shortcode', $_POST['_format_gallery_preview_shortcode']);
+	}
+	if (!defined('XMLRPC_REQUEST') && isset($_POST['_format_gallery_checked_shortcode'])) {
+		update_post_meta($post_id, '_format_gallery_checked_shortcode', $_POST['_format_gallery_checked_shortcode']);
+	}
+	if (!defined('XMLRPC_REQUEST') && isset($_POST['_format_gallery_checked_allimages'])) {
+		update_post_meta($post_id, '_format_gallery_checked_shortcode', $_POST['_format_gallery_checked_shortcode']);
 	}
 }
 // action added in cfpf_admin_init()

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -251,4 +251,5 @@ function cfpf_social_broadcast_format($format, $post) {
 }
 add_filter('social_broadcast_format', 'cfpf_social_broadcast_format', 10, 2);
 
+
 } // end defined check

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -203,14 +203,17 @@ function cfpf_format_audio_save_post($post_id) {
  * @return void
  */
 function cfpf_format_gallery_save_post( $post_id ) {
-	if ( !defined( 'XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_preview_shortcode'] ) ) {
-		update_post_meta( $post_id, '_format_gallery_preview_shortcode', $_POST['_format_gallery_preview_shortcode']);
-	}
-	if ( !defined( 'XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_checked_shortcode'] ) ) {
-		update_post_meta( $post_id, '_format_gallery_checked_shortcode', sanitize_text_field( $_POST['_format_gallery_checked_shortcode'] ) );
-	}
-	if ( !defined( 'XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_checked_allimages'] ) ) {
-		update_post_meta( $post_id, '_format_gallery_checked_shortcode', $_POST['_format_gallery_checked_shortcode']);
+	if (!defined('XMLRPC_REQUEST')) {
+		$keys = array(
+			'_format_gallery_preview_shortcode',
+			'_format_gallery_checked_shortcode',
+			'_format_gallery_checked_allimages'
+		);
+		foreach ($keys as $key) {
+			if (isset($_POST[$key])) {
+				update_post_meta($post_id, $key, $_POST[$key]);
+			}
+		}
 	}
 }
 // action added in cfpf_admin_init()
@@ -261,10 +264,12 @@ function shortcode_gallery_atts( $atts ) {
 	$shortcode = get_post_meta($post->ID, '_format_gallery_checked_shortcode', true);
 	//Work in progress. First try at using an actual short code as input. There could be lots of variations on what a user puts in here in an actual
 	//shorttag. The question is to you try to filter all the possible scode params?
-	//$shortcodeatts = shortcode_parse_atts( get_post_meta($post->ID, '_format_gallery_preview_shortcode', true) );
+	$shortcodeatts = shortcode_parse_atts( get_post_meta($post->ID, '_format_gallery_preview_shortcode', true) );
+
+	var_dump($shortcodeatts);
 	
 	//Using a comma separated list for now of desired image ids.
-	$shortcodeatts = get_post_meta($post->ID, '_format_gallery_preview_shortcode', true);
+	//$shortcodeatts = get_post_meta($post->ID, '_format_gallery_preview_shortcode', true);
 
 	//get all the attachments already on the post to filter them out.
 	$attachments = get_children( array(

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -249,54 +249,6 @@ function cfpf_post_has_gallery($post_id = null) {
 	return (bool) $images->post_count;
 }
 
-/**
- * Callback from the shortcode_atts_{gallery} filter
- * which allows us to manipulate the default gallery settings.
- * In this case we are going to override showing all posts
- * with the user defined ones instead.
- *
- * 
- * @param array $atts The default gallery array of data i.e. all attachemnts. 
- * @return array $atts our alternate gallery shortcode.
- */
-function shortcode_gallery_atts( $atts ) {
-	global $post;
-	$shortcode = get_post_meta($post->ID, '_format_gallery_checked_shortcode', true);
-	//Work in progress. First try at using an actual short code as input. There could be lots of variations on what a user puts in here in an actual
-	//shorttag. The question is to you try to filter all the possible scode params?
-	$shortcodeatts = shortcode_parse_atts( get_post_meta($post->ID, '_format_gallery_preview_shortcode', true) );
-
-	var_dump($shortcodeatts);
-	
-	//Using a comma separated list for now of desired image ids.
-	//$shortcodeatts = get_post_meta($post->ID, '_format_gallery_preview_shortcode', true);
-
-	//get all the attachments already on the post to filter them out.
-	$attachments = get_children( array(
-	'post_parent'    => $attr['id'],
-	'post_status'    => 'inherit',
-	'post_type'      => 'attachment',
-	'post_mime_type' => 'image',
-	'order'          => $attr['order'],
-	'orderby'        => $attr['orderby'],
-	) );
-	
-	$excludeids = implode( ",", array_keys($attachments) );
-
-	if ( $shortcode == 'shortcode' && !empty($shortcodeatts)) {
-		if ( ( 'gallery' ) ) {
-			$atts['exclude'] = $excludeids;
-			$atts['include'] = $shortcodeatts;
-			$atts['columns'] = '4';
-		}
-	}
-
-	return $atts;
-		
-	}
-
-add_filter( 'shortcode_atts_gallery', 'shortcode_gallery_atts', 10, 1 );
-
 function cfpf_pre_ping_post_links($post_links, $pung, $post_id = null) {
 	// return if we don't get a post ID (pre WP 3.4)
 	if (empty($post_id)) {

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -194,15 +194,15 @@ function cfpf_format_audio_save_post($post_id) {
 }
 // action added in cfpf_admin_init()
 
-function cfpf_format_gallery_save_post($post_id) {
-	if (!defined('XMLRPC_REQUEST') && isset($_POST['_format_gallery_preview_shortcode'])) {
-		update_post_meta($post_id, '_format_gallery_preview_shortcode', $_POST['_format_gallery_preview_shortcode']);
+function cfpf_format_gallery_save_post( $post_id ) {
+	if ( !defined( 'XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_preview_shortcode'] ) ) {
+		update_post_meta( $post_id, '_format_gallery_preview_shortcode', $_POST['_format_gallery_preview_shortcode']);
 	}
-	if (!defined('XMLRPC_REQUEST') && isset($_POST['_format_gallery_checked_shortcode'])) {
-		update_post_meta($post_id, '_format_gallery_checked_shortcode', $_POST['_format_gallery_checked_shortcode']);
+	if ( !defined( 'XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_checked_shortcode'] ) ) {
+		update_post_meta( $post_id, '_format_gallery_checked_shortcode', sanitize_text_field( $_POST['_format_gallery_checked_shortcode'] ) );
 	}
-	if (!defined('XMLRPC_REQUEST') && isset($_POST['_format_gallery_checked_allimages'])) {
-		update_post_meta($post_id, '_format_gallery_checked_shortcode', $_POST['_format_gallery_checked_shortcode']);
+	if ( !defined('XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_checked_allimages'] ) ) {
+		update_post_meta( $post_id, '_format_gallery_checked_shortcode', $_POST['_format_gallery_checked_shortcode']);
 	}
 }
 // action added in cfpf_admin_init()
@@ -241,15 +241,32 @@ function cfpf_post_has_gallery($post_id = null) {
 function shortcode_gallery_atts( $atts ) {
 	global $post;
 	$shortcode = get_post_meta($post->ID, '_format_gallery_checked_shortcode', true);
-	$shortcodeatts = shortcode_parse_atts( get_post_meta($post->ID, '_format_gallery_preview_shortcode', true) );
-	var_dump($shortcodeatts);
+	//First try used an acuatl short code as input. There could be lots of variations on what a user puts in here in an actual
+	//shorttag. The questio is to you try to fileter all the possible scode params?
+	//$shortcodeatts = shortcode_parse_atts( get_post_meta($post->ID, '_format_gallery_preview_shortcode', true) );
+	
+	$shortcodeatts = get_post_meta($post->ID, '_format_gallery_preview_shortcode', true);
+
+	//get all the attachments already on the post to filter them out.
+	$attachments = get_children( array(
+	'post_parent'    => $attr['id'],
+	'post_status'    => 'inherit',
+	'post_type'      => 'attachment',
+	'post_mime_type' => 'image',
+	'order'          => $attr['order'],
+	'orderby'        => $attr['orderby'],
+	) );
+	
+	$excludeids = implode( ",", array_keys($attachments) );
+
 	if ( $shortcode == 'shortcode' && !empty($shortcodeatts)) {
 		if ( ( 'gallery' ) ) {
-		$atts['columns'] = '4';
+			$atts['exclude'] = $excludeids;
+			$atts['include'] = $shortcodeatts;
+			$atts['columns'] = '4';
 		}
 	}
 
-		
 	return $atts;
 		
 	}

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -259,10 +259,11 @@ function cfpf_post_has_gallery($post_id = null) {
 function shortcode_gallery_atts( $atts ) {
 	global $post;
 	$shortcode = get_post_meta($post->ID, '_format_gallery_checked_shortcode', true);
-	//First try used an acuatl short code as input. There could be lots of variations on what a user puts in here in an actual
-	//shorttag. The questio is to you try to fileter all the possible scode params?
+	//Work in progress. First try at using an actual short code as input. There could be lots of variations on what a user puts in here in an actual
+	//shorttag. The question is to you try to filter all the possible scode params?
 	//$shortcodeatts = shortcode_parse_atts( get_post_meta($post->ID, '_format_gallery_preview_shortcode', true) );
 	
+	//Using a comma separated list for now of desired image ids.
 	$shortcodeatts = get_post_meta($post->ID, '_format_gallery_preview_shortcode', true);
 
 	//get all the attachments already on the post to filter them out.

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -194,6 +194,14 @@ function cfpf_format_audio_save_post($post_id) {
 }
 // action added in cfpf_admin_init()
 
+/**
+ * Updates the _format_gallery values in the DB for
+ * the radio buttons and text field in the gallery format tab.
+ *
+ * 
+ * @param int $post_id The id of the post.
+ * @return void
+ */
 function cfpf_format_gallery_save_post( $post_id ) {
 	if ( !defined( 'XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_preview_shortcode'] ) ) {
 		update_post_meta( $post_id, '_format_gallery_preview_shortcode', $_POST['_format_gallery_preview_shortcode']);
@@ -201,7 +209,7 @@ function cfpf_format_gallery_save_post( $post_id ) {
 	if ( !defined( 'XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_checked_shortcode'] ) ) {
 		update_post_meta( $post_id, '_format_gallery_checked_shortcode', sanitize_text_field( $_POST['_format_gallery_checked_shortcode'] ) );
 	}
-	if ( !defined('XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_checked_allimages'] ) ) {
+	if ( !defined( 'XMLRPC_REQUEST' ) && isset( $_POST['_format_gallery_checked_allimages'] ) ) {
 		update_post_meta( $post_id, '_format_gallery_checked_shortcode', $_POST['_format_gallery_checked_shortcode']);
 	}
 }
@@ -238,6 +246,16 @@ function cfpf_post_has_gallery($post_id = null) {
 	return (bool) $images->post_count;
 }
 
+/**
+ * Callback from the shortcode_atts_{gallery} filter
+ * which allows us to manipulate the default gallery settings.
+ * In this case we are going to override showing all posts
+ * with the user defined ones instead.
+ *
+ * 
+ * @param array $atts The default gallery array of data i.e. all attachemnts. 
+ * @return array $atts our alternate gallery shortcode.
+ */
 function shortcode_gallery_atts( $atts ) {
 	global $post;
 	$shortcode = get_post_meta($post->ID, '_format_gallery_checked_shortcode', true);

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -206,8 +206,7 @@ function cfpf_format_gallery_save_post( $post_id ) {
 	if (!defined('XMLRPC_REQUEST')) {
 		$keys = array(
 			'_format_gallery_preview_shortcode',
-			'_format_gallery_checked_shortcode',
-			'_format_gallery_checked_allimages'
+			'_format_gallery_type'
 		);
 		foreach ($keys as $key) {
 			if (isset($_POST[$key])) {

--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -238,6 +238,24 @@ function cfpf_post_has_gallery($post_id = null) {
 	return (bool) $images->post_count;
 }
 
+function shortcode_gallery_atts( $atts ) {
+	global $post;
+	$shortcode = get_post_meta($post->ID, '_format_gallery_checked_shortcode', true);
+	$shortcodeatts = shortcode_parse_atts( get_post_meta($post->ID, '_format_gallery_preview_shortcode', true) );
+	var_dump($shortcodeatts);
+	if ( $shortcode == 'shortcode' && !empty($shortcodeatts)) {
+		if ( ( 'gallery' ) ) {
+		$atts['columns'] = '4';
+		}
+	}
+
+		
+	return $atts;
+		
+	}
+
+add_filter( 'shortcode_atts_gallery', 'shortcode_gallery_atts', 10, 1 );
+
 function cfpf_pre_ping_post_links($post_links, $pung, $post_id = null) {
 	// return if we don't get a post ID (pre WP 3.4)
 	if (empty($post_id)) {

--- a/css/admin.css
+++ b/css/admin.css
@@ -77,10 +77,6 @@
 	background: #fff;
 }
 
-.cf-elem-inline {
-	display:inline-block;
-}
-
 /* Video Field */
 #cfpf-format-video-embed {
 	height: 65px;

--- a/css/admin.css
+++ b/css/admin.css
@@ -77,6 +77,10 @@
 	background: #fff;
 }
 
+.cf-elem-inline {
+	display:inline-block;
+}
+
 /* Video Field */
 #cfpf-format-video-embed {
 	height: 65px;

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -5,7 +5,7 @@
 	<div class="cf-elm-container">
 		<p>
 			<input type="radio" name="_format_gallery_type" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_type', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode"  /> Shortcode
-			<span style="display:inline-block;"><input type="text" name="_format_gallery_preview_shortcode" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_gallery_preview_shortcode', true)); ?>" id="cfpf-format-gallery-preview-shortcode" tabindex="1" /></span>
+			<span style="display:inline-block;"><input type="text" name="_format_gallery_preview_shortcode" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_gallery_preview_shortcode', true)); ?>" id="cfpf-format-gallery-preview-shortcode" /></span>
 		</p>
 		<p>
 			<input type="radio" name="_format_gallery_type" value="attached-images" id="attached-images" <?php checked( get_post_meta($post->ID, '_format_gallery_type', true), 'attached-images' ); ?>" id="cfpf-format-gallery-checked-allimages"  /> All Images

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -4,13 +4,14 @@
 	<div class="cf-elm-container">
 		<div class="cf-elm-block">
 			<div class="cf-elem-inline">
-				<input type="radio" name="gallerygroup" value="shortcode" id="shortcode"> Gallery Shortcode
+				<?php var_dump(get_post_meta($post->ID, '_format_gallery_checked_shortcode', false), 1 ); ?>
+				<input type="radio" name="_format_gallery_checked_shortcode" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode" tabindex="1" /> Gallery Shortcode
 			</div>
 			<div class="cf-elem-inline">
 				<input type="text" name="_format_gallery_preview_shortcode" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_gallery_preview_shortcode', true)); ?>" id="cfpf-format-gallery-preview-shortcode" tabindex="1" />
 			</div>
 			<div>
-				<input type="radio" name="gallerygroup" value="defaultgallery" checked> All Images
+				<input type="radio" name="_format_gallery_checked_shortcode" value="allimages" id="allimages" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'allimages' ); ?>" id="cfpf-format-gallery-checked-allimages" tabindex="1" /> All Images
 			</div>
 	</div>
 

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -1,18 +1,16 @@
 <div id="cfpf-format-gallery-preview" class="cf-elm-block cf-elm-block-image" style="display: none;">
 
 	<label><span><?php _e('Gallery Images', 'cf-post-format'); ?></span></label>
+	
 	<div class="cf-elm-container">
-		<div class="cf-elm-block">
-			<div class="cf-elem-inline">
-				<input type="radio" name="_format_gallery_type" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_type', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode" tabindex="1" /> Shortcode
-			</div>
-			<div class="cf-elem-inline">
-				<input type="text" name="_format_gallery_preview_shortcode" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_gallery_preview_shortcode', true)); ?>" id="cfpf-format-gallery-preview-shortcode" tabindex="1" />
-			</div>
-			<div>
-				<input type="radio" name="_format_gallery_type" value="attached-images" id="attached-images" <?php checked( get_post_meta($post->ID, '_format_gallery_type', true), 'attached-images' ); ?>" id="cfpf-format-gallery-checked-allimages" tabindex="1" /> All Images
-			</div>
-	</div>
+		<p>
+			<input type="radio" name="_format_gallery_type" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_type', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode"  /> Shortcode
+			<span style="display:inline-block;"><input type="text" name="_format_gallery_preview_shortcode" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_gallery_preview_shortcode', true)); ?>" id="cfpf-format-gallery-preview-shortcode" tabindex="1" /></span>
+		</p>
+		<p>
+			<input type="radio" name="_format_gallery_type" value="attached-images" id="attached-images" <?php checked( get_post_meta($post->ID, '_format_gallery_type', true), 'attached-images' ); ?>" id="cfpf-format-gallery-checked-allimages"  /> All Images
+		</p>
+
 
 <?php
 

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -4,13 +4,13 @@
 	<div class="cf-elm-container">
 		<div class="cf-elm-block">
 			<div class="cf-elem-inline">
-				<input type="radio" name="_format_gallery_checked_shortcode" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode" tabindex="1" /> Shortcode
+				<input type="radio" name="_format_gallery_type" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_type', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode" tabindex="1" /> Shortcode
 			</div>
 			<div class="cf-elem-inline">
 				<input type="text" name="_format_gallery_preview_shortcode" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_gallery_preview_shortcode', true)); ?>" id="cfpf-format-gallery-preview-shortcode" tabindex="1" />
 			</div>
 			<div>
-				<input type="radio" name="_format_gallery_checked_shortcode" value="allimages" id="allimages" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'allimages' ); ?>" id="cfpf-format-gallery-checked-allimages" tabindex="1" /> All Images
+				<input type="radio" name="_format_gallery_type" value="attached-images" id="attached-images" <?php checked( get_post_meta($post->ID, '_format_gallery_type', true), 'attached-images' ); ?>" id="cfpf-format-gallery-checked-allimages" tabindex="1" /> All Images
 			</div>
 	</div>
 

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -4,7 +4,6 @@
 	<div class="cf-elm-container">
 		<div class="cf-elm-block">
 			<div class="cf-elem-inline">
-				<?php var_dump(get_post_meta($post->ID, '_format_gallery_checked_shortcode', false), 1 ); ?>
 				<input type="radio" name="_format_gallery_checked_shortcode" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode" tabindex="1" /> Gallery Shortcode
 			</div>
 			<div class="cf-elem-inline">

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -1,6 +1,18 @@
 <div id="cfpf-format-gallery-preview" class="cf-elm-block cf-elm-block-image" style="display: none;">
+
 	<label><span><?php _e('Gallery Images', 'cf-post-format'); ?></span></label>
 	<div class="cf-elm-container">
+		<div class="cf-elm-block">
+			<div class="cf-elem-inline">
+				<input type="radio" name="gallerygroup" value="shortcode" id="shortcode"> Gallery Shortcode
+			</div>
+			<div class="cf-elem-inline">
+				<input type="text" name="_format_gallery_preview_shortcode" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_gallery_preview_shortcode', true)); ?>" id="cfpf-format-gallery-preview-shortcode" tabindex="1" />
+			</div>
+			<div>
+				<input type="radio" name="gallerygroup" value="defaultgallery" checked> All Images
+			</div>
+	</div>
 
 <?php
 
@@ -14,6 +26,7 @@ $attachments = get_posts(array(
 	'order' => 'ASC',
 	'orderby' => 'menu_order ID',
 ));
+
 if ($attachments) {
 	echo '<ul class="gallery">';
 	foreach ($attachments as $attachment) {

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -4,13 +4,13 @@
 	<div class="cf-elm-container">
 		<div class="cf-elm-block">
 			<div class="cf-elem-inline">
-				<input type="radio" name="_format_gallery_checked_shortcode" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode" tabindex="1" /> Gallery Shortcode
+				<input type="radio" name="_format_gallery_checked_shortcode" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode" tabindex="1" /> Use alternate image id's
 			</div>
 			<div class="cf-elem-inline">
 				<input type="text" name="_format_gallery_preview_shortcode" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_gallery_preview_shortcode', true)); ?>" id="cfpf-format-gallery-preview-shortcode" tabindex="1" />
 			</div>
 			<div>
-				<input type="radio" name="_format_gallery_checked_shortcode" value="allimages" id="allimages" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'allimages' ); ?>" id="cfpf-format-gallery-checked-allimages" tabindex="1" /> All Images
+				<input type="radio" name="_format_gallery_checked_shortcode" value="allimages" id="allimages" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'allimages' ); ?>" id="cfpf-format-gallery-checked-allimages" tabindex="1" /> Use all attached images (default)
 			</div>
 	</div>
 

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -4,13 +4,13 @@
 	<div class="cf-elm-container">
 		<div class="cf-elm-block">
 			<div class="cf-elem-inline">
-				<input type="radio" name="_format_gallery_checked_shortcode" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode" tabindex="1" /> Use alternate image id's
+				<input type="radio" name="_format_gallery_checked_shortcode" id="shortcode" value="shortcode" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'shortcode' ); ?>" id="cfpf-format-gallery-checked-shortcode" tabindex="1" /> Shortcode
 			</div>
 			<div class="cf-elem-inline">
 				<input type="text" name="_format_gallery_preview_shortcode" value="<?php echo esc_attr(get_post_meta($post->ID, '_format_gallery_preview_shortcode', true)); ?>" id="cfpf-format-gallery-preview-shortcode" tabindex="1" />
 			</div>
 			<div>
-				<input type="radio" name="_format_gallery_checked_shortcode" value="allimages" id="allimages" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'allimages' ); ?>" id="cfpf-format-gallery-checked-allimages" tabindex="1" /> Use all attached images (default)
+				<input type="radio" name="_format_gallery_checked_shortcode" value="allimages" id="allimages" <?php checked( get_post_meta($post->ID, '_format_gallery_checked_shortcode', true), 'allimages' ); ?>" id="cfpf-format-gallery-checked-allimages" tabindex="1" /> All Images
 			</div>
 	</div>
 


### PR DESCRIPTION
A stab at adding the option to override the default [gallery] tag behavior which displays all images uploaded/attached to the post. The user can check "Use alternate image id's" and pass comma separated ids of any images to override the default [gallery] behavior. This is using the WordPress shortcode_atts_{gallery} filter to manipulate the gallery output.
![screen shot 2014-08-22 at 2 31 32 pm](https://cloud.githubusercontent.com/assets/1243118/4017033/9af58ecc-2a3b-11e4-9230-c7c602b11916.png)
