### PR TITLE
support drag and drop sorting in the gallery preview

### DIFF
--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -60,6 +60,11 @@ function cfpf_admin_init() {
 			add_action('save_post', 'cfpf_format_gallery_save_post');
 		}
 	}
+	// add sortable JS for gallery
+	global $pagenow;
+	if (in_array($pagenow, array('post.php', 'post-new.php'))) {
+		wp_enqueue_script('jquery-ui-sortable');
+	}
 }
 add_action('admin_init', 'cfpf_admin_init');
 
@@ -233,9 +238,38 @@ function cfpf_gallery_preview() {
 }
 add_action('wp_ajax_cfpf_gallery_preview', 'cfpf_gallery_preview');
 
+function cfpf_gallery_menu_order() {
+	if (!empty($_POST['order']) && is_array($_POST['order'])) {
+		$i = 0;
+		foreach ($_POST['order'] as $post_id) {
+			$post_id = intval($post_id);
+			if ($post_id) {
+				wp_update_post(array(
+					'ID' => $post_id,
+					'menu_order' => $i
+				));
+				++$i;
+			}
+		}
+		header('Content-type: text/javascript');
+		echo json_encode(array(
+			'result' => 'success'
+		));
+		die();
+	}
+}
+add_action('wp_ajax_cfpf_gallery_menu_order', 'cfpf_gallery_menu_order');
+
+function cfpf_gallery_image_id($attr, $attachment) {
+	$attr['data-id'] = $attachment->ID;
+	return $attr;
+}
+add_filter('wp_get_attachment_image_attributes', 'cfpf_gallery_image_id', 10, 2);
+
 // filter added conditionally in views/format-gallery.php
 function cfpf_ssl_gallery_preview($attr, $attachment) {
 	$attr['src'] = str_replace('http://', 'https://', $attr['src']);
+	$attr['data-id'] = $attachment->ID;
 	return $attr;
 }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -78,7 +78,9 @@
 	padding-bottom: 8px;
 }
 .cf-elm-block .cf-elm-container .gallery li {
-	display: inline-block;
+	cursor: move;
+	display: block;
+	float: left;
 	margin: 0 8px 8px 0;
 	padding: 0;
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -80,8 +80,31 @@ jQuery(function($) {
 				$('#cfpf-format-link-url, #cfpf-format-quote-fields, #cfpf-format-video-fields, #cfpf-format-gallery-preview').hide();
 				$('#titlewrap, #cfpf-format-audio-fields').show();
 				$('#postimagediv-placeholder').replaceWith($('#postimagediv'));
-			}
+			},
 
+			gallerySortable: function() {
+				$galleryPreview = $('#cfpf-format-gallery-preview .gallery');
+				$galleryPreview.sortable({
+					containment: 'parent',
+					cursor: 'move',
+					forceHelperSize: true,
+					forcePlaceholderSize: true,
+					update: function() {
+						var ids = [];
+						$galleryPreview.find('img.attachment-thumbnail').each(function() {
+							ids.push($(this).data('id'));
+						});
+
+						$.post(
+							ajaxurl,
+							{
+								'action': 'cfpf_gallery_menu_order',
+								'order': ids
+							}
+						);
+					}
+				});
+			}
 		};
 	}(jQuery);
 	
@@ -145,16 +168,18 @@ jQuery(function($) {
 				if ($('#cf-post-format-tabs a.current').attr('href').indexOf('#post-format-gallery') != -1) {
 					$preview.show();
 				}
+
+				CF.postFormats.gallerySortable();
 			},
 			'json'
 		);
 
 	}, gallery );
 
-	
 	$(document).on('click', '#cfpf-format-gallery-preview .none a', function(e) {
 		$('#wp-content-media-buttons .insert-media').mousedown().mouseup().click();
 		e.preventDefault();
 	});
 
+	CF.postFormats.gallerySortable();
 });

--- a/views/format-gallery.php
+++ b/views/format-gallery.php
@@ -38,7 +38,7 @@ if ($attachments) {
 		add_filter('wp_get_attachment_image_attributes', 'cfpf_ssl_gallery_preview', 10, 2);
 	}
 
-	echo '<ul class="gallery">';
+	echo '<ul class="gallery clearfix">';
 	foreach ($attachments as $attachment) {
 		echo '<li>'.wp_get_attachment_image($attachment->ID, 'thumbnail').'</li>';
 	}
@@ -46,6 +46,8 @@ if ($attachments) {
 }
 
 ?>
-<p class="none"><a href="#" class="button"><?php _e('Upload Images', 'cf-post-format'); ?></a></p>
+		<p class="none" style="float: none; clear: both;">
+			<a href="#" class="button"><?php _e('Upload Images', 'cf-post-format'); ?></a>
+		</p>
 	</div>
 </div>


### PR DESCRIPTION
This implements jQuery sortables for the gallery post format tab, to set the `menu_order` for the images attached to the page. Drag and drop to order, an AJAX call is sent with the new order, then caught on the back-end and properties set accordingly.

Just like the last one - not doing Ridiculous Whitespace in order to keep the files here consistent. Sorry - maybe next time. :)
