### PR TITLE
Check for the existance of valid $post

### DIFF
--- a/cf-post-formats.php
+++ b/cf-post-formats.php
@@ -223,11 +223,12 @@ function cfpf_format_gallery_save_post( $post_id ) {
 // action added in cfpf_admin_init()
 
 function cfpf_gallery_preview() {
-	if (empty($_POST['id']) || !($post_id = intval($_POST['id']))) {
+	global $post;
+
+	if (empty($_POST['id']) || !($post_id = intval($_POST['id'])) || !$post) {
 		exit;
 	}
 
-	global $post;
 	$post = get_post($post_id);
 	ob_start();
 	include('views/format-gallery.php');


### PR DESCRIPTION
Sometimes there is no global $post object so changing the parameter of it throws a PHP warning.
